### PR TITLE
JWT 인증/인가 기능을 핸들링하는 클라이언트 로직

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -40,9 +40,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 
-    // session
-    implementation 'org.springframework.session:spring-session-data-redis'
-
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/chat/src/main/java/com/heri2go/chat/config/RedisConfig.java
+++ b/chat/src/main/java/com/heri2go/chat/config/RedisConfig.java
@@ -1,9 +1,7 @@
 package com.heri2go.chat.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.session.data.redis.config.annotation.web.server.EnableRedisWebSession;
 
-@EnableRedisWebSession
 @Configuration
 public class RedisConfig {
 

--- a/chat/src/main/java/com/heri2go/chat/config/SecurityConfig.java
+++ b/chat/src/main/java/com/heri2go/chat/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authentication.RedirectServerAuthenticationFailureHandler;
+import org.springframework.security.web.server.authentication.RedirectServerAuthenticationSuccessHandler;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
 
 import com.heri2go.chat.filter.JwtAuthenticationFilter;
@@ -30,9 +32,13 @@ public class SecurityConfig {
         return http
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(form -> form
+                        .loginPage("/login.html")
+                        .authenticationSuccessHandler(new RedirectServerAuthenticationSuccessHandler("/chat.html"))
+                        .authenticationFailureHandler(new RedirectServerAuthenticationFailureHandler("/login.html")))
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/api/auth/**").permitAll()
-                        .pathMatchers("/login.html", "/register.html", "/css/**", "/js/**", "/img/**").permitAll()
+                        .pathMatchers("/login.html", "/register.html", "/css/**", "/js/**", "/img/**", "/favicon.ico").permitAll()
                         .anyExchange().authenticated())
                 .authenticationManager(authenticationManager())
                 .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)

--- a/chat/src/main/java/com/heri2go/chat/web/service/chat/SentimentService.java
+++ b/chat/src/main/java/com/heri2go/chat/web/service/chat/SentimentService.java
@@ -51,7 +51,7 @@ public class SentimentService {
                     .map(response -> {
                         JsonNode documentSentiment = response.get("documentSentiment");
                         double score = documentSentiment.get("score").asDouble();
-                        double magnitude = documentSentiment.get("magnitude").asDouble();
+                        // double magnitude = documentSentiment.get("magnitude").asDouble(); <- 이후 감정값 계산 시 사용 예정, 현재는 단순 값 반환
                         
                         log.debug("Sentiment analysis completed. Score: {}", score);
                         return score;


### PR DESCRIPTION
JWT 인증/인가 서버의 API를 핸들링하는 클라이언트를 구성 시도했지만, 순수 html + js 나 서버사이드 렌더링 방식으로는 불가능하다고 판단하고 정리한다.